### PR TITLE
Refactor learning steps API usage

### DIFF
--- a/src/hooks/learning-steps/useFetchLearningSteps.ts
+++ b/src/hooks/learning-steps/useFetchLearningSteps.ts
@@ -1,6 +1,6 @@
 
 import { useCallback } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { fetchSteps } from "@/services/learningStepsService";
 import { LearningStepData } from "./types";
 
 export const useFetchLearningSteps = () => {
@@ -16,32 +16,12 @@ export const useFetchLearningSteps = () => {
     
     try {
       console.log("Fetching learning steps for path:", pathId);
-      
-      const { data, error } = await supabase
-        .from('learning_steps')
-        .select('*')
-        .eq('path_id', pathId)
-        .order('order_index', { ascending: true });
 
-      if (error) {
-        console.error("Error fetching learning steps:", error);
-        return;
-      }
+      const processedData = await fetchSteps(pathId);
 
-      if (data && data.length > 0) {
-        console.log(`Retrieved ${data.length} learning steps for path:`, pathId);
-        
-        // Process data to ensure all values are properly formatted as strings
-        const processedData = data.map(step => ({
-          ...step,
-          content: typeof step.content === 'string' 
-            ? step.content 
-            : (step.content ? JSON.stringify(step.content) : "No content available"),
-          detailed_content: typeof step.detailed_content === 'string'
-            ? step.detailed_content
-            : (step.detailed_content ? JSON.stringify(step.detailed_content) : null)
-        }));
-        
+      if (processedData.length > 0) {
+        console.log(`Retrieved ${processedData.length} learning steps for path:`, pathId);
+
         // Always update steps to ensure freshness
         setSteps(processedData);
         

--- a/src/hooks/learning-steps/useRealtimeUpdates.ts
+++ b/src/hooks/learning-steps/useRealtimeUpdates.ts
@@ -1,22 +1,14 @@
 import { useEffect, useRef } from "react";
-import { supabase } from "@/integrations/supabase/client";
-import { LearningStepData } from "./types";
+import { subscribeToStepUpdates } from "@/services/learningStepsService";
 
 export const useRealtimeUpdates = (
   pathId: string | null,
-  countGeneratedSteps: (stepsArray: LearningStepData[]) => number,
-  setSteps: React.Dispatch<React.SetStateAction<LearningStepData[]>>,
-  setGeneratedSteps: React.Dispatch<React.SetStateAction<number>>,
-  setGeneratingContent: React.Dispatch<React.SetStateAction<boolean>>,
-  generatedSteps: number,
   fetchLearningSteps: Function
 ) => {
   // Track last update time to throttle updates
   const lastUpdateRef = useRef<number>(Date.now());
   const updateThrottleMs = 500; // Further reduced throttle time for more frequent updates
   
-  // Track subscription status
-  const subscriptionActive = useRef<boolean>(false);
 
   useEffect(() => {
     if (!pathId) return;
@@ -26,63 +18,34 @@ export const useRealtimeUpdates = (
     
     // Set up subscription to track generation progress
     try {
-      const channel = supabase.channel(`steps-${pathId}`);
-      
-      const subscription = channel
-        .on('postgres_changes', 
-          { 
-            event: 'UPDATE', 
-            schema: 'public', 
-            table: 'learning_steps',
-            filter: `path_id=eq.${pathId}`
-          }, 
-          (payload) => {
-            console.log('Step updated (realtime):', payload.new.id);
-            
-            // Throttle updates to prevent excessive re-renders but keep it fast enough to show progress
-            const now = Date.now();
-            if (now - lastUpdateRef.current < updateThrottleMs) {
-              return; // Skip this update if too soon after the last one
-            }
-            lastUpdateRef.current = now;
-            
-            // Force a refresh of all steps to ensure we have the latest data
-            fetchLearningSteps();
-          }
-        )
-        .subscribe((status) => {
-          console.log(`Realtime subscription status: ${status}`);
-          subscriptionActive.current = status === 'SUBSCRIBED';
-          
-          // If subscription failed, fall back to polling
-          if (status === 'CLOSED' || status === 'CHANNEL_ERROR') {
-            console.log('Subscription failed, falling back to polling');
-            subscriptionActive.current = false;
-            
-            // Set up polling as fallback - use a ref to track the interval
-            const pollInterval = setInterval(() => {
-              fetchLearningSteps();
-            }, 2000); // Poll every 2 seconds
-            
-            return () => clearInterval(pollInterval);
-          }
-        });
-        
+      const unsubscribe = subscribeToStepUpdates(pathId, (payload) => {
+        console.log('Step updated (realtime):', payload.new.id);
+
+        // Throttle updates to prevent excessive re-renders but keep it fast enough to show progress
+        const now = Date.now();
+        if (now - lastUpdateRef.current < updateThrottleMs) {
+          return; // Skip this update if too soon after the last one
+        }
+        lastUpdateRef.current = now;
+
+        // Force a refresh of all steps to ensure we have the latest data
+        fetchLearningSteps();
+      });
+
       console.log("Subscription to learning steps updates established");
-        
+
       // Set up polling even with active subscription as a backup
       const backupPollInterval = setInterval(() => {
         fetchLearningSteps();
       }, 5000); // Backup poll every 5 seconds
-        
+
       return () => {
-        channel.unsubscribe();
-        subscriptionActive.current = false;
+        unsubscribe();
         clearInterval(backupPollInterval);
       };
     } catch (error) {
       console.error("Error setting up realtime subscription:", error);
-      
+
       // If subscription setup fails, fall back to aggressive polling
       const pollInterval = setInterval(() => {
         fetchLearningSteps();

--- a/src/hooks/learning-steps/useStepCompletion.ts
+++ b/src/hooks/learning-steps/useStepCompletion.ts
@@ -1,6 +1,6 @@
 
 import { useCallback } from "react";
-import { supabase } from "@/integrations/supabase/client";
+import { markStepComplete } from "@/services/learningStepsService";
 import { LearningStepData } from "./types";
 
 export const useStepCompletion = (
@@ -15,26 +15,19 @@ export const useStepCompletion = (
         )
       );
 
-      // Then update the database
-      const { error } = await supabase
-        .from('learning_steps')
-        .update({ completed: true })
-        .eq('id', stepId);
+      await markStepComplete(stepId);
 
-      if (error) {
-        console.error("Error marking step as complete:", error);
-
-        // Revert optimistic update if server update fails
-        setSteps(prevSteps =>
-          prevSteps.map(step =>
-            step.id === stepId ? { ...step, completed: false } : step
-          )
-        );
-        return false;
-      }
       return true;
     } catch (error) {
       console.error("Error marking step as complete:", error);
+
+      // Revert optimistic update if server update fails
+      setSteps(prevSteps =>
+        prevSteps.map(step =>
+          step.id === stepId ? { ...step, completed: false } : step
+        )
+      );
+
       return false;
     }
   }, [setSteps]);

--- a/src/hooks/useLearningSteps.tsx
+++ b/src/hooks/useLearningSteps.tsx
@@ -56,11 +56,6 @@ export const useLearningSteps = (pathId: string | null, topic: string | null) =>
   // Set up realtime updates
   useRealtimeUpdates(
     pathId,
-    countGeneratedSteps,
-    setSteps,
-    setGeneratedSteps,
-    setGeneratingContent,
-    generatedSteps,
     fetchSteps
   );
 

--- a/src/services/learningStepsService.ts
+++ b/src/services/learningStepsService.ts
@@ -1,0 +1,76 @@
+import { supabase } from "@/integrations/supabase/client";
+import { LearningStepData } from "@/hooks/learning-steps/types";
+
+/**
+ * Fetch all learning steps for a given path.
+ */
+export const fetchSteps = async (pathId: string): Promise<LearningStepData[]> => {
+  const { data, error } = await supabase
+    .from('learning_steps')
+    .select('*')
+    .eq('path_id', pathId)
+    .order('order_index', { ascending: true });
+
+  if (error) {
+    console.error('Error fetching learning steps:', error);
+    throw error;
+  }
+
+  if (!data) return [];
+
+  return data.map(step => ({
+    ...step,
+    content: typeof step.content === 'string'
+      ? step.content
+      : (step.content ? JSON.stringify(step.content) : 'No content available'),
+    detailed_content: typeof step.detailed_content === 'string'
+      ? step.detailed_content
+      : (step.detailed_content ? JSON.stringify(step.detailed_content) : null)
+  }));
+};
+
+/**
+ * Mark a learning step as completed.
+ */
+export const markStepComplete = async (stepId: string): Promise<void> => {
+  const { error } = await supabase
+    .from('learning_steps')
+    .update({ completed: true })
+    .eq('id', stepId);
+
+  if (error) {
+    console.error('Error marking step as complete:', error);
+    throw error;
+  }
+};
+
+/**
+ * Subscribe to realtime updates for learning steps belonging to a path.
+ * Returns an unsubscribe function.
+ */
+export const subscribeToStepUpdates = (
+  pathId: string,
+  onUpdate: (payload: any) => void
+): (() => void) => {
+  const channel = supabase.channel(`steps-${pathId}`);
+
+  channel
+    .on('postgres_changes',
+      {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'learning_steps',
+        filter: `path_id=eq.${pathId}`
+      },
+      onUpdate
+    )
+    .subscribe((status) => {
+      if (status !== 'SUBSCRIBED') {
+        console.log(`Subscription status: ${status}`);
+      }
+    });
+
+  return () => {
+    channel.unsubscribe();
+  };
+};


### PR DESCRIPTION
## Summary
- centralize learning steps Supabase calls in `learningStepsService`
- update hooks to use new service API
- simplify realtime updates hook API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*
- `npm test` *(fails: Missing script 'test')*