### PR TITLE
docs: add user documentation for LearnFlow AI

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,13 @@
+# LearnFlow AI Overview
+
+LearnFlow AI is an AI‑powered learning companion that turns any topic into a personalized learning project. It guides you from your first idea to completion with structured plans, engaging content, and progress tracking.
+
+## Key Features
+
+- **AI‑Generated Learning Plans** – Enter a topic and instantly receive a step‑by‑step plan that breaks the subject into manageable milestones.
+- **Focused Learning Content** – Each step includes concise explanations that help you understand the material without feeling overwhelmed.
+- **Project Tracking** – Save learning projects, revisit them anytime, and monitor your progress as you complete steps.
+- **Audio Summaries** – Generate an AI‑narrated audio overview of your project to review on the go.
+- **Podcast Creator (Coming Soon)** – A conversational podcast version of your topic is in development.
+
+LearnFlow AI removes the guesswork from self‑learning and keeps you motivated with clear next steps.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,38 @@
+# LearnFlow AI User Guide
+
+This guide walks you through the typical journey of using LearnFlow AI. No technical background is required—just bring a topic you want to learn.
+
+## 1. Start a New Project
+
+1. Open the home page.
+2. Enter a topic that interests you, such as "introduction to machine learning" or "digital marketing basics."
+3. Submit the topic to let the AI create a learning path.
+
+## 2. Review Your Plan
+
+- The Plan page shows a list of learning steps generated for your topic.
+- Approve the plan to continue, or reset it to try a different topic.
+- Each step includes a short title that describes what you'll learn next.
+
+## 3. Explore the Content
+
+- After approving a plan, you are taken to the Content page.
+- Read the material for each step and use the navigation buttons to move forward or backward.
+- Mark steps as complete to track your progress.
+
+## 4. Manage Your Projects
+
+- Visit the Projects page to see every learning path you've saved.
+- Open a project to continue where you left off or delete projects you no longer need.
+- Use the "Start a New Learning Project" button to create another plan at any time.
+
+## 5. Listen to Audio Summaries
+
+- The Audio page lets you generate an AI‑narrated summary of your project.
+- Play the audio inside the app or generate a new recording whenever the project changes.
+
+## 6. Coming Soon: Podcast Creator
+
+- A podcast version of your project will soon let you listen to a dialogue between AI hosts discussing your topic.
+
+Enjoy a smoother, more focused learning experience with LearnFlow AI!


### PR DESCRIPTION
## Summary
- add overview of LearnFlow AI features
- document user flow from starting a project to audio summaries

## Testing
- `npm run lint` *(fails: 67 problems in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68a82cbbf7f083338ec2d7525a6e6f38