### PR TITLE
docs: add learning projects guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ Simply open [Lovable](https://lovable.dev/projects/6c0ee66d-d0fe-49f5-adbb-dd19d
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## Learning Projects Guide
+
+For tips on creating and working through learning projects, see the [Learning Projects Guide](docs/projects.md).

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,0 +1,34 @@
+# Learning Projects Guide
+
+LearnFlow helps you turn any topic into a structured learning project. This guide explains how to create new projects, work through each learning step, and use the platform's tools to get the most from your study time.
+
+## Create a New Project
+
+1. **Start from the home page.** Enter a topic in the input box and submit it to generate a personalized learning path.
+2. **Wait for the plan to generate.** LearnFlow checks for existing projects and, if needed, calls AI services to build step‑by‑step lessons for your topic.
+3. **Review and approve.** After the plan appears, approve it to save the project and continue to the content.
+
+## Explore a Project
+
+- **Read through steps.** Each project is divided into ordered steps with explanations and examples.
+- **Track your position.** A progress indicator and navigation controls show where you are in the path and let you jump to other steps.
+- **Mark steps complete.** Finished steps update the project’s progress so you can pick up right where you left off.
+
+## Manage Your Projects
+
+- **Project dashboard.** The Projects page lists all of your learning paths with their current completion percentage.
+- **Delete or start over.** Remove projects you no longer need or begin a new one at any time.
+
+## Additional Learning Tools
+
+- **Margin notes and concepts.** While reading content, LearnFlow can surface margin notes and highlight key concepts for deeper understanding.
+- **Audio summaries.** Generate an AI‑voiced summary of an entire project to review lessons hands‑free.
+- **Upcoming features.** A podcast creator for conversational recaps is under development.
+
+## Tips for Effective Learning
+
+- Revisit projects regularly to reinforce knowledge.
+- Use related topics and deep‑dive links to explore material beyond the core steps.
+- Combine reading with audio summaries to engage multiple senses.
+
+With these features, LearnFlow transforms broad topics into focused learning experiences that adapt to your progress.


### PR DESCRIPTION
## Summary
- add Learning Projects Guide explaining how to start and manage learning projects
- link the new guide from the README for easier discovery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a82d7ded648333a40d73eb5057916f